### PR TITLE
Removing some package_check upgrade

### DIFF
--- a/check_process
+++ b/check_process
@@ -17,10 +17,6 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		# 1.3.1
-		upgrade=1	from_commit=22ca62492ce32d22ac710758bca4e3be0534566c
-		# 1.4.1
-		upgrade=1	from_commit=33620aacc6f6e2ac003ae6bd2de57dc5d74a5343
 		# 2.0.0
 		upgrade=1	from_commit=032acd21b36030c9c1680d882d54c8011439e83c
 		# 2.1.0


### PR DESCRIPTION
As installation for those versions failed on buster

## Solution
- *Fix #159*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/peertube_ynh%20PR-NUM-%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/peertube_ynh%20PR-NUM-%20(yalh76)/)  
