### PR TITLE
Add french to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,14 +31,17 @@
                 "name": "domain",
                 "type": "domain",
                 "ask": {
-                    "en": "Choose a domain name for PeerTube"
+                    "en": "Choose a domain name for PeerTube",
+                    "fr": "Choisissez un nom de domaine pour PeerTube"
                 },
                 "example": "example.com"
             },
             {
                 "name": "email",
+                "type": "string",
                 "ask": {
-                    "en": "Choose an admin email (can be changed after installation)"
+                    "en": "Choose an admin email (can be changed after installation)",
+                    "fr": "Choisissez une adresse e-mail d'administrateur (peut être modifiée après l'installation)"
                 },
                 "example": "johndoe@example.com"
             },
@@ -46,7 +49,8 @@
                 "name": "is_public",
                 "type": "boolean",
                 "ask": {
-                    "en": "Is it a public application?"
+                    "en": "Is it a public application?",
+                    "fr": "Est-ce une application publique ?"
                 },
                 "default": true
             }


### PR DESCRIPTION
## Problem
- *No french translation in manifest*

## Solution
- *Add french translation in manifest*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/peertube_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/peertube_ynh%20PR-NUM-%20(USERNAME)/)  
