### PR TITLE
Fixes a key issue when installing Yarn

### DIFF
--- a/check_process
+++ b/check_process
@@ -28,7 +28,7 @@
 		# 2.4.0~ynh1
 		upgrade=1	from_commit=10d79175a8a45137d271931cbd6d14e927400729
 		backup_restore=1
-		multi_instance=1
+		multi_instance=0
 		port_already_use=0
 		change_url=0
 ;;; Options

--- a/scripts/install
+++ b/scripts/install
@@ -96,6 +96,7 @@ else
 fi
 
 # Install Yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - 2>&1
 ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -113,6 +113,7 @@ else
 fi
 
 # Install Yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - 2>&1
 ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -177,6 +177,7 @@ else
 fi
 
 # Install Yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - 2>&1
 ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 # Remove hook


### PR DESCRIPTION
## Problem
- *Yarn Debian key expiry date updated (EXPKEYSIG 23E7166788B63E1E) *

## Solution
- *upgrade the version of the GPG key used to sign Yarn releases*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/peertube_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/peertube_ynh%20PR-NUM-%20(USERNAME)/)  
