### PR TITLE
Fix plugins cannot be installed

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,6 +6,7 @@ After=network.target postgresql.service redis-server.service
 Type=simple
 Environment=NODE_ENV=production
 Environment=NODE_CONFIG_DIR=__FINALPATH__/config
+Environment="__YNH_NODE_LOAD_PATH__"
 User=__APP__
 Group=__APP__
 ExecStart=__YNH_NODE__ __FINALPATH__/dist/server

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Video streaming platform using P2P directly in the web browser, connected to a federated network",
         "fr": "Plateforme de diffusion vidéo par P2P directement dans le navigateur, et connectée à un réseau fédéralisé"
     },
-    "version": "3.3.0~ynh2",
+    "version": "3.3.0~ynh3",
     "url": "https://github.com/Chocobozzz/PeerTube",
     "upstream": {
         "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Problem

I want to be able to install plugins like [`peertube-plugin-creative-commons`](https://github.com/beeldengeluid/peertube-plugin-creative-commons) (using the web interface, going to `/admin/plugins/search?pluginType=1` and searching for `creative-commons`).

But there seems to have conflicts about the nodejs version used by the application and the one used by default by the host (nodejs v8).

## Solution

- I manage to use __YNH_NODE_LOAD_PATH__ in systemd so the node subprocesses use the same nodejs version as the one used by the peertube process

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
