### PR TITLE
allow device access to gpu hardware acceleration

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -22,11 +22,12 @@ Restart=always
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
 NoNewPrivileges=yes
 PrivateTmp=yes
-PrivateDevices=yes
+#PrivateDevices=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 RestrictNamespaces=yes
 RestrictRealtime=yes
 DevicePolicy=closed
+DeviceAllow=/dev/dri/renderD128
 ProtectSystem=full
 ProtectControlGroups=yes
 ProtectKernelModules=yes


### PR DESCRIPTION
`PrivateDevices=yes`
prevents PeerTube to use the device for gpu / hardware accelerated transcoding.

fixes #296 

needs review.