### PR TITLE
Add patch for python path in config file

### DIFF
--- a/conf/production.yaml
+++ b/conf/production.yaml
@@ -433,7 +433,9 @@ import:
 
         # youtube-dl binary name
         # yt-dlp is also supported
-        name: 'youtube-dl'
+        name: 'yt-dlp'
+        # Path to the python binary to execute for youtube-dl or yt-dlp
+        python_path: '/usr/bin/python3'
 
       # IPv6 is very strongly rate-limited on most sites supported by youtube-dl
       force_ipv4: false

--- a/scripts/install
+++ b/scripts/install
@@ -70,7 +70,7 @@ ynh_app_setting_set --app=$app --key=port --value=$port
 
 # PeerTube Live port
 rtmp_port=1935
-ynh_port_available --port=$rtmp_port || ynh_die "Port $rtmp_port is needs to be available for this app"
+ynh_port_available --port=$rtmp_port || ynh_die --message="Port $rtmp_port is needs to be available for this app"
 ynh_app_setting_set --app=$app --key=rtmp_port --value=$rtmp_port
 
 # Open the port
@@ -130,6 +130,7 @@ ynh_script_progression --message="Setting up source files..."
 
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 # Download, check integrity, uncompress and patch the source from app.src
+[ -d "../sources/patches-$(ynh_app_upstream_version)" ] && cp -a "../sources/patches-$(ynh_app_upstream_version)" "../sources/patches"
 ynh_setup_source --dest_dir="$final_path"
 
 chmod 750 "$final_path"
@@ -164,7 +165,7 @@ ynh_script_progression --message="Building Yarn dependencies..."
 
 pushd "$final_path"
 	ynh_use_nodejs
-	ynh_exec_warn_less sudo -u $app env $ynh_node_load_PATH yarn install --production --pure-lockfile 
+	ynh_exec_warn_less sudo -u $app env $ynh_node_load_PATH yarn install --production --pure-lockfile
 popd
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -119,7 +119,7 @@ ynh_delete_file_checksum --file="../conf/msg_install"
 if [ -z "$rtmp_port" ];
 then
 	rtmp_port=1935
-	ynh_port_available --port=$rtmp_port || ynh_die "Port $rtmp_port is needs to be available for this app"
+	ynh_port_available --port=$rtmp_port || ynh_die --message="Port $rtmp_port is needs to be available for this app"
 	ynh_app_setting_set --app=$app --key=rtmp_port --value=$rtmp_port
 
 	# Open the port
@@ -169,6 +169,7 @@ then
 	ynh_secure_remove --file="$final_path"
 
 	# Download, check integrity, uncompress and patch the source from app.src
+        [ -d "../sources/patches-$(ynh_app_upstream_version)" ] && cp -a "../sources/patches-$(ynh_app_upstream_version)" "../sources/patches"
 	ynh_setup_source --dest_dir="$final_path"
 
 	#Copy the admin saved settings from tmp directory to final path

--- a/sources/patches-4.0.0/app-python-in-config.patch
+++ b/sources/patches-4.0.0/app-python-in-config.patch
@@ -1,0 +1,26 @@
+diff '--color=auto' -ru ./dist/server/helpers/youtube-dl/youtube-dl-cli.js ./dist/server/helpers/youtube-dl/youtube-dl-cli.js
+--- ./dist/server/helpers/youtube-dl/youtube-dl-cli.js	2021-12-13 09:22:44.000000000 +0100
++++ ./dist/server/helpers/youtube-dl/youtube-dl-cli.js	2022-01-11 22:35:52.992330841 +0100
+@@ -104,7 +104,8 @@
+             let completeArgs = this.wrapWithProxyOptions(args);
+             completeArgs = this.wrapWithIPOptions(completeArgs);
+             completeArgs = this.wrapWithFFmpegOptions(completeArgs);
+-            const output = yield (0, execa_1.default)('python', [youtubeDLBinaryPath, ...completeArgs, url], processOptions);
++            const { PYTHON_PATH } = config_1.CONFIG.IMPORT.VIDEOS.HTTP.YOUTUBE_DL_RELEASE;
++            const output = yield (0, execa_1.default)(PYTHON_PATH, [youtubeDLBinaryPath, ...completeArgs, url], processOptions);
+             logger_1.logger.debug('Runned youtube-dl command.', Object.assign({ command: output.command }, lTags()));
+             return output.stdout
+                 ? output.stdout.trim().split(/\r?\n/)
+diff '--color=auto' -ru ./dist/server/initializers/config.js ./dist/server/initializers/config.js
+--- ./dist/server/initializers/config.js	2021-12-13 09:22:43.000000000 +0100
++++ ./dist/server/initializers/config.js	2022-01-11 22:35:51.812344562 +0100
+@@ -295,7 +295,8 @@
+                 get ENABLED() { return config.get('import.videos.http.enabled'); },
+                 YOUTUBE_DL_RELEASE: {
+                     get URL() { return config.get('import.videos.http.youtube_dl_release.url'); },
+-                    get NAME() { return config.get('import.videos.http.youtube_dl_release.name'); }
++                    get NAME() { return config.get('import.videos.http.youtube_dl_release.name'); },
++                    get PYTHON_PATH() { return config.get('import.videos.http.youtube_dl_release.python_path'); }
+                 },
+                 get FORCE_IPV4() { return config.get('import.videos.http.force_ipv4'); }
+             },


### PR DESCRIPTION
## Problem

See https://github.com/YunoHost-Apps/peertube_ynh/issues/295

## Solution

Apply [this patch](https://github.com/Chocobozzz/PeerTube/commit/22c777863088f90c7f3f9df613b42952abab856d) (compiled from typescript to javascript) that has been accepted upstream.

Note that this patch can be removed once the upstream app has released a new version.

What do you think? I would really need this patch for my personal use, but I can understand that you may not want to add patches to the project and prefer to wait.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
