### PR TITLE
Add note about production.yaml in README

### DIFF
--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -27,6 +27,8 @@ By watching a video, you help the hosting provider to broadcast it by becoming a
 * This app is **multi-instance** (you can have more then one PeerTube instance running on a YunoHost server)
 * **If you are hosted on OVH virtual machine or experiencing `gyp ERR! configure error`, please switch to [ovh_fix](https://github.com/YunoHost-Apps/peertube_ynh/tree/ovh_fix)**
 * HTTP auth is not supported
+* Do not modify the `/var/www/<app>/conf/production.yaml` file, because it will be overridden in the next upgrade. Please instead either change them though the web interface or create a `/var/www/<app>/conf/local.yaml` file, assign it the same owner, group and rights than for `conf/production.yaml` and fill there your specific settings.
+    * Note: when the same option have different values in `production.yaml` and `local.yaml` files, only the value in `local.yaml` is taken into account.
 
 ### PLUGINS
 * LDAP auth is supported, LDAP configuration will be sent to the email address given at the time of the installation.

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -24,6 +24,9 @@ En regardant une vidéo, vous aidez l'hébergeur à la diffuser en devenant vous
 
 * Cette application est **multi-instance** (vous pouvez avoir plus d'une instance PeerTube en cours d'exécution sur un serveur YunoHost)
 * **Si vous êtes hébergé sur une machine virtuelle OVH ou rencontrez `gyp ERR! configure error`, veuillez passer à [ovh_fix](https://github.com/YunoHost-Apps/peertube_ynh/tree/ovh_fix)**
+* L'authentification HTTP n'est pas supportée
+* Ne modifiez pas le fichier `/var/www/<app>/conf/production.yaml`, car il sera remplacé à la prochaine mise à jour. À la place, veuillez modifier la configuration via l'interface web ou créer et remplir le fichier `/var/www/<app>/conf/local.yaml`, assignez-lui les mêmes propriétaire, groupe et droits que pour `conf/production.yaml` et y remplir vos options spécifiques.
+    * Note: si la même option contient différentes valeurs dans les fichiers `conf/production.yaml` et `conf/local.yaml`, seule la valeur dans `conf/local.yaml` sera prise en compte.
 
 #### PLUGINS
 


### PR DESCRIPTION
## Problem

- See #348, production.yaml is overridden after each upgrade

## Solution

- Tell that to the user the production.yaml in the README file
- Also invite them to rather fill the `config/local.yaml` file instead 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
