### PR TITLE
Fix config local.yaml file wiped out on app upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -165,34 +165,9 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..."
 
-	# Create a temporary directory
-	tmpdir="$(mktemp -d)"
-
-	# Backup the config file in the temp dir
-	cp -af "$final_path/config/production.yaml" "$tmpdir/production.yaml"
-	if [ -s "$final_path/config/local-production.json" ]
-	then
-		cp -af "$final_path/config/local-production.json" "$tmpdir/local-production.json"
-	fi
-
-	# Remove the app directory securely
-	ynh_secure_remove --file="$final_path"
-
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$final_path"
-
-	#Copy the admin saved settings from tmp directory to final path
-	cp -af "$tmpdir/production.yaml" "$final_path/config/production.yaml"
-
-	if [ -s "$tmpdir/local-production.json" ]
-	then
-		cp -af "$tmpdir/local-production.json" "$final_path/config/local-production.json"
-	else
-		cp ../conf/local-production.json "$final_path/config/local-production.json"
-	fi
-
-	# Remove the tmp directory securely
-	ynh_secure_remove --file="$tmpdir"
+	ynh_setup_source --full_replace=1 --dest_dir="$final_path" \
+		--keep="config/production.yaml config/local-production.json config/local.yaml"
 fi
 
 chmod 750 "$final_path"


### PR DESCRIPTION
## Problem

- When upgrading for a new app version, the local.yaml file is wiped out (close #353)

## Solution

- use the `--keep` option of `ynh_setup_source` in order to keep the `local.yaml` file and other ones which were saved
   - Please note that PeerTube does not need `local-production.json` to run and it creates it when it needs to store information in it, I tend to believe that installing this file through the Yunohost package is unnecessary.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
