### PR TITLE
Systemd wait for dbinit

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -164,9 +164,9 @@ ynh_script_progression --message="Building Yarn dependencies..."
 pushd "$final_path"
 	ynh_use_nodejs
 	npm install -g npm
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$final_path/config" NODE_ENV=production yarn config set network-timeout 300000
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$final_path/config" NODE_ENV=production yarn install --production --pure-lockfile
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$final_path/config" NODE_ENV=production yarn cache clean
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn config set network-timeout 300000
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install --production --pure-lockfile
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn cache clean
 popd
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -164,7 +164,7 @@ ynh_script_progression --message="Building Yarn dependencies..."
 pushd "$final_path"
 	ynh_use_nodejs
 	npm install -g npm
-  ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn config set network-timeout 300000
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn config set network-timeout 300000
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install --production --pure-lockfile
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn cache clean
 popd

--- a/scripts/install
+++ b/scripts/install
@@ -200,7 +200,7 @@ ynh_script_progression --message="Starting a systemd service..."
 mkdir -p "/var/log/$app"
 chown -R $app:$app "/var/log/$app"
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Started"
+ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="HTTP server listening on localhost"
 
 #=================================================
 # INSTALL LDAP PLUGIN

--- a/scripts/install
+++ b/scripts/install
@@ -164,9 +164,9 @@ ynh_script_progression --message="Building Yarn dependencies..."
 pushd "$final_path"
 	ynh_use_nodejs
 	npm install -g npm
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn config set network-timeout 300000
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install --production --pure-lockfile
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn cache clean
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$final_path/config" NODE_ENV=production yarn config set network-timeout 300000
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$final_path/config" NODE_ENV=production yarn install --production --pure-lockfile
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$final_path/config" NODE_ENV=production yarn cache clean
 popd
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -163,6 +163,7 @@ ynh_script_progression --message="Building Yarn dependencies..."
 
 pushd "$final_path"
 	ynh_use_nodejs
+        ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn config set network-timeout 300000
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install --production --pure-lockfile
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn cache clean
 popd

--- a/scripts/restore
+++ b/scripts/restore
@@ -144,7 +144,7 @@ yunohost service add $app --description="$app daemon for Peertube" --log="/var/l
 #=================================================
 ynh_script_progression --message="Starting a systemd service..."
 
-ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Started"
+ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="HTTP server listening on localhost"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -260,7 +260,7 @@ ynh_script_progression --message="Starting a systemd service..."
 mkdir -p "/var/log/$app"
 chown -R $app:$app "/var/log/$app"
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Started"
+ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="HTTP server listening on localhost"
 
 #=================================================
 # INSTALL LDAP PLUGIN


### PR DESCRIPTION
https://github.com/YunoHost-Apps/peertube_ynh/pull/397#issuecomment-1870324009

Database isn't initialized completely all the time before using it (LDAP plugin installation), so we should wait for it.

Thanks @alexAubin  and @Chocobozzz  for you help ! 🙂

Fix #390 #386

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
