### PR TITLE
Fix autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -44,7 +44,8 @@ ram.runtime = "1G"
         [resources.sources.main]
         url = "https://github.com/Chocobozzz/PeerTube/releases/download/v6.0.3/peertube-v6.0.3.tar.xz"
         sha256 = "9a88899a4777c340df41e763ecdf8656edf3ef75f54b4de9be05aa309697a211"
-        autoupdate.strategy = "latest_github_tag"
+        autoupdate.strategy = "latest_github_release"
+        autoupdate.asset = "^peertube-v.*\\.tar\\.xz$"
 
     [resources.ports]
     main.default = 8095


### PR DESCRIPTION
## Problem

- The autoupdate fetches the `.tar.gz` archive, which leads to installation failure (see #432)

## Solution

- Fetch the `tar.xz` archive which is already built

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
