### PR TITLE
6.3.1 #450 migration AFTER start systemd

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "PeerTube"
 description.en = "Federated video streaming platform using P2P directly in the web browser"
 description.fr = "Plateforme fédéralisé de diffusion vidéo par P2P directement dans le navigateur"
 
-version = "6.3.0~ynh1"
+version = "6.3.1~ynh1"
 
 maintainers = [ ]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -42,8 +42,8 @@ ram.runtime = "1G"
 
 [resources]
         [resources.sources.main]
-        url = "https://github.com/Chocobozzz/PeerTube/releases/download/v6.3.0/peertube-v6.3.0.tar.xz"
-        sha256 = "286f7712392a981b336630feb4f398b75de7d1db285e5f2d9fa5c38d85e052f4"
+        url = "https://github.com/Chocobozzz/PeerTube/releases/download/v6.3.1/peertube-v6.3.1.tar.xz"
+        sha256 = "654036b4cefd773ee40d01a7b2b65e95d892297958b3e1719d9e31dd09149853"
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset = "^peertube-v.*\\.tar\\.xz$"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -168,18 +168,27 @@ if ynh_compare_current_package_version --comparison lt --version 5.0.0~ynh1; the
 	popd
 fi
 
-if ynh_compare_current_package_version --comparison lt --version 6.3.0~ynh1; then
-	ynh_script_progression --message="Running Peertube 6.3.0 migration script..."
-	pushd "$install_dir"
-		ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production $ynh_node dist/scripts/migrations/peertube-6.3.js
-	popd
-fi
+
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting systemd service..."
 
 ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="HTTP server listening on 127.0.0.1"
+#=================================================
+# START Database Migration
+#=================================================
+
+if ynh_compare_current_package_version --comparison lt --version 6.3.0~ynh1; then
+	sleep 20 
+	#arbitrary sleep duration, possibly optional, may vary depending on database size.
+	ynh_script_progression --message="Running Peertube 6.3.0 migration script..."
+	pushd "$install_dir"
+		ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production $ynh_node dist/scripts/migrations/peertube-6.3.js
+	popd
+fi
+
+
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

DB migration failed

## Solution

Put it after the service is started, per the official documentation.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

I installed a new peertube instance, uploaded a few videos, upgraded to this branch. It worked just fine. Please modify to your heart's content.

I also [upgraded my main instance](https://paste.yunohost.org/raw/riwukefemo) after creating a full backup.

Install log (YNH provided 6.2.1): https://paste.yunohost.org/raw/nagipabeyi

Upgrade log (this branch 6.3.0): https://paste.yunohost.org/raw/ijugurecox

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

Could I become a member of the ynh apps organization so that I may run these tests? I would like to become more involved with yunohost.