### PR TITLE
Uncomment chown command for log directory

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -40,7 +40,7 @@ yunohost service add "$app" --description="Federated video streaming platform" -
 
 mkdir -p "/var/log/$app"
 touch "/var/log/$app/peertube.log"
-#chown -R $app:$app "/var/log/$app"
+chown -R $app:$app "/var/log/$app"
 ynh_restore "/etc/logrotate.d/$app"
 
 #=================================================


### PR DESCRIPTION
## Problem

See this comment:
https://forum.yunohost.org/t/impossible-de-restaurer-une-sauvegarde-de-peertube/40021/27

The user could not write in the peertube log directory. Probably due to the fact that the restored folder ownership has changed (the uid is preserved but has been attributed to another app)

## Solution

Uncomment chown command in the restore script.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
