### PR TITLE
Fix pnpm arguments for PeerTube 8 compatibility in install/upgrade scripts

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -90,9 +90,9 @@ ynh_systemctl --service=$app --action="start" --log_path="systemd" --wait_until=
 ynh_script_progression "Installing $app plugin and password..."
 
 pushd "$install_dir"
-	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install -- --npm-name peertube-plugin-auth-ldap
-	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install -- --npm-name peertube-plugin-livechat
-	echo "$admin_pass" | ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run reset-password -- -u root
+	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install --npm-name peertube-plugin-auth-ldap
+	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install --npm-name peertube-plugin-livechat
+	echo "$admin_pass" | ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run reset-password -u root
 popd
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -113,8 +113,8 @@ ynh_systemctl --service="$app" --action="start" --log_path="systemd" --wait_unti
 ynh_script_progression "Installing $app plugin..."
 
 pushd "$install_dir"
-	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install -- --npm-name peertube-plugin-auth-ldap
-	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install -- --npm-name peertube-plugin-livechat
+	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install --npm-name peertube-plugin-auth-ldap
+	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install --npm-name peertube-plugin-livechat
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem
Description of why you made this PR
The installation fails with error: `[too many arguments. Expected 0 arguments but got 2]` [(log) ](https://ci-apps-dev.yunohost.org/ci/job/15865#:~:text=74218%20INFO%20%20%20%20DEBUG%20%2D%20error%3A%20too%20many%20arguments.%20Expected%200%20arguments%20but%20got%202.) during plugin installation. This is maybe caused by the usage of the -- separator in pnpm run commands, which causes subsequent arguments (like --npm-name) to be misinterpreted in the current PeerTube 8 environment.


## Solution
And how do you fix that problem
Removed the -- separator from pnpm run calls in scripts/install and scripts/upgrade to correctly pass arguments to the underlying scripts.

## PR Status
- [x] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)