### PR TITLE
Clean old yarn config for PeerTube 8 upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,6 +112,14 @@ ynh_systemctl --service="$app" --action="start" --log_path="systemd" --wait_unti
 #=================================================
 ynh_script_progression "Installing $app plugin..."
 
+# Remove old package.json and yarn.lock from plugins directory to avoid conflict with pnpm
+if [ -f "$data_dir/storage/plugins/package.json" ]; then
+    ynh_safe_rm "$data_dir/storage/plugins/package.json"
+fi
+if [ -f "$data_dir/storage/plugins/yarn.lock" ]; then
+    ynh_safe_rm "$data_dir/storage/plugins/yarn.lock"
+fi
+
 pushd "$install_dir"
 	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install --npm-name peertube-plugin-auth-ldap
 	ynh_hide_warnings ynh_exec_as_app NODE_CONFIG_DIR="$install_dir/config" NODE_ENV=production pnpm run plugin:install --npm-name peertube-plugin-livechat


### PR DESCRIPTION
## Problem
Upgrade from v7 fails because pnpm refuses to run plugin installation when it detects a packageManager: yarn configuration in the existing plugins directory (as reported in issue #512).
## Solution
The script now cleans up legacy `yarn.lock` and `package.json` files from the plugins directory in scripts/upgrade before installing plugins, allowing pnpm to proceed correctly. It also adjusts pnpm command arguments for compatibility.
Fixes #512

_Note: I've tested this on my side and it seems to work, but I am not an expert so please review carefully/verify via CI._

## PR Status
[x] Code finished and ready to be reviewed/tested
[x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)