### PR TITLE
Fix DDOS attack by preventing too much proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Federated video streaming platform
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://joinpeertube.org/fr)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](http://peertube.cpy.re)
-[![Version: 8.1.5~ynh1](https://img.shields.io/badge/Version-8.1.5~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/peertube/)
+[![Version: 8.1.5~ynh2](https://img.shields.io/badge/Version-8.1.5~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/peertube/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/peertube"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -159,6 +159,8 @@ location ~ ^(/static/(webseed|web-videos|streaming-playlists/hls)/private/)|^/do
   proxy_set_header Host            $host;
   proxy_set_header X-Real-IP       $remote_addr;
 
+  # Prevent too much proxying, which results in high disk write IO
+  proxy_max_temp_file_size 50M;
   proxy_limit_rate 5M;
 
   proxy_pass http://127.0.0.1:__PORT__;

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "PeerTube"
 description.en = "Federated video streaming platform"
 description.fr = "Plateforme fédéralisé de diffusion vidéo"
 
-version = "8.1.5~ynh1"
+version = "8.1.5~ynh2"
 
 maintainers = [ ]
 


### PR DESCRIPTION
## Problem

I get many requests to download videos. These request come from various countries, especially from Vietnam, Pakistan, Bengladesh, Iraq, and look very close to this issue:
https://github.com/Chocobozzz/PeerTube/issues/7547#issue-4220978471

## Solution

See: https://github.com/Chocobozzz/PeerTube/issues/7547#issuecomment-4245055225

It's been deployed on our PeerTube instance. I am observing whether it works or not. But anyway, seems legit to deploy it.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
